### PR TITLE
Error handling for controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 require 'application_responder'
+require 'renderable_error'
 
 class ApplicationController < ActionController::API
   ANY_FORMAT = '*/*'.freeze
@@ -20,7 +21,7 @@ class ApplicationController < ActionController::API
 
   def validate_url_param
     return if url_param_key && acceptable_url_params.include?(params[url_param_key])
-    render text: 'Requested entity sub-type is not available', status: 400
+    render_error 400, 'Requested entity sub-type is not available'
   end
 
   def url_param_key
@@ -29,6 +30,10 @@ class ApplicationController < ActionController::API
 
   def acceptable_url_params
     [] # implement this in Resource/Link/Mixin controllers
+  end
+
+  def render_error(code, message)
+    respond_with RenderableError.new(code, message), status: code
   end
 
   private

--- a/app/controllers/link_controller.rb
+++ b/app/controllers/link_controller.rb
@@ -14,13 +14,19 @@ class LinkController < ApplicationController
   def create; end
 
   # POST /link/:link/:id?action=ACTION
-  def execute; end
+  def execute
+    render_error 501, 'Requested functionality is not implemented'
+  end
 
   # PUT /link/:link/:id
-  def update; end
+  def update
+    render_error 501, 'Requested functionality is not implemented'
+  end
 
   # POST /link/:link/:id
-  def partial_update; end
+  def partial_update
+    render_error 501, 'Requested functionality is not implemented'
+  end
 
   # DELETE /link/:link/:id
   def delete; end

--- a/app/controllers/mixin_controller.rb
+++ b/app/controllers/mixin_controller.rb
@@ -9,7 +9,7 @@ class MixinController < ApplicationController
 
   # POST /mixin/:parent/:term/
   def assign
-    render text: 'Requested functionality is not implemented', status: 501
+    render_error 501, 'Requested functionality is not implemented'
   end
 
   # POST /mixin/:parent/:term/?action=ACTION
@@ -17,7 +17,7 @@ class MixinController < ApplicationController
 
   # PUT /mixin/:parent/:term/
   def update
-    render text: 'Requested functionality is not implemented', status: 501
+    render_error 501, 'Requested functionality is not implemented'
   end
 
   # DELETE /mixin/:parent/:term/

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -17,7 +17,9 @@ class ResourceController < ApplicationController
   def execute; end
 
   # PUT /:resource/:id
-  def update; end
+  def update
+    render_error 501, 'Requested functionality is not implemented'
+  end
 
   # POST /:resource/:id
   def partial_update; end

--- a/app/controllers/server_model_controller.rb
+++ b/app/controllers/server_model_controller.rb
@@ -11,20 +11,17 @@ class ServerModelController < ApplicationController
 
   # GET /-/
   # GET /.well-known/org/ogf/occi/-/
-  def show
-    model = ::Occi::InfrastructureExt::Model.new
-    model.load_core!
-    model.load_infrastructure!
-    model.load_infrastructure_ext!
-
-    respond_with model
-  end
+  def show; end
 
   # POST /-/
   # POST /.well-known/org/ogf/occi/-/
-  def mixin_create; end
+  def mixin_create
+    render_error 501, 'Requested functionality is not implemented'
+  end
 
   # DELETE /-/
   # DELETE /.well-known/org/ogf/occi/-/
-  def mixin_delete; end
+  def mixin_delete
+    render_error 501, 'Requested functionality is not implemented'
+  end
 end

--- a/lib/renderable_error.rb
+++ b/lib/renderable_error.rb
@@ -1,0 +1,23 @@
+class RenderableError
+  HEADERS_KEY = 'X-OCCI-Error'.freeze
+
+  attr_accessor :code, :message
+
+  def initialize(code, message)
+    @code = code
+    @message = message || 'Unspecified error'
+  end
+
+  def to_json
+    { code: code, message: message }.to_json
+  end
+
+  def to_headers
+    { HEADERS_KEY => to_s }
+  end
+
+  def to_s
+    "#{code} #{message}"
+  end
+  alias_method :to_text, :to_s
+end

--- a/lib/renderable_error.rb
+++ b/lib/renderable_error.rb
@@ -19,5 +19,5 @@ class RenderableError
   def to_s
     "#{code} #{message}"
   end
-  alias_method :to_text, :to_s
+  alias to_text to_s
 end


### PR DESCRIPTION
Errors that need to be sent to the client are unified and automatically
rendered into the appropriate media type via `RenderableError`
instances. This is currently applied only to explicitly raised errors
but /in the near future/ will be applied to errors rescued by the
controller as well.