### PR TITLE
Updated backend init mechanism

### DIFF
--- a/app/models/backend_proxy.rb
+++ b/app/models/backend_proxy.rb
@@ -66,7 +66,7 @@ class BackendProxy
   end
 
   def default_backend_options
-    { logger: logger }
+    { logger: logger, backend_proxy: self }
   end
 
   def backend_namespace

--- a/app/models/backends/aws_ec2.rb
+++ b/app/models/backends/aws_ec2.rb
@@ -1,3 +1,4 @@
 module Backends
   module AwsEc2; end
 end
+Dir.glob(File.join(File.dirname(__FILE__), 'aws_ec2', '*.rb')) { |mod| require mod.chomp('.rb') }

--- a/app/models/backends/base.rb
+++ b/app/models/backends/base.rb
@@ -1,0 +1,30 @@
+module Backends
+  class Base
+    attr_reader :options, :logger, :backend_proxy
+    delegate :api_version, to: :class
+
+    def initialize(args = {})
+      pre_initialize(args)
+
+      @options = args
+      @logger = args.fetch(:logger)
+      @backend_proxy = args.fetch(:backend_proxy)
+
+      post_initialize(args)
+    end
+
+    class << self
+      def api_version
+        self::API_VERSION
+      end
+    end
+
+    protected
+
+    # :nodoc:
+    def pre_initialize(args); end
+
+    # :nodoc:
+    def post_initialize(args); end
+  end
+end

--- a/app/models/backends/dummy/base.rb
+++ b/app/models/backends/dummy/base.rb
@@ -1,20 +1,7 @@
 module Backends
   module Dummy
-    class Base
+    class Base < ::Backends::Base
       API_VERSION = '3.0.0'.freeze
-
-      attr_reader :options
-      delegate :api_version, to: :class
-
-      def initialize(options = {})
-        @options = options
-      end
-
-      class << self
-        def api_version
-          API_VERSION
-        end
-      end
     end
   end
 end

--- a/app/models/backends/opennebula.rb
+++ b/app/models/backends/opennebula.rb
@@ -1,3 +1,4 @@
 module Backends
   module OpenNebula; end
 end
+Dir.glob(File.join(File.dirname(__FILE__), 'opennebula', '*.rb')) { |mod| require mod.chomp('.rb') }


### PR DESCRIPTION
## Overview
Backend instances can use `*_initialize` methods exposed by `::Backends::Base` and passed down to `::Backends::*::Base` to initialize platform-specific internals. There is no need to override the original `initialize` method (because that is _technically_ part of the backend API and could be tricky).

## Changes
* Introducing `pre_initialize` and `post_initialize` hooks
* Creating a common `Base` class for all backends
* Passing backend proxy instance downstream