### PR TITLE
Basic MultiEntity support in controller(s)

### DIFF
--- a/app/controllers/concerns/locations_transformable.rb
+++ b/app/controllers/concerns/locations_transformable.rb
@@ -1,0 +1,52 @@
+module LocationsTransformable
+  extend ActiveSupport::Concern
+
+  # A way to separate Resources from Links
+  LINK_PATH_PREFIX = '/link/'.freeze
+
+  included do
+    delegate :link_path_prefix, to: :class
+  end
+
+  class_methods do
+    # @see `LINK_PATH_PREFIX`
+    def link_path_prefix
+      LINK_PATH_PREFIX
+    end
+  end
+
+  # Converts given enumerable structure to an instance of `Occi::Core::Locations`
+  # for later rendering or further processing.
+  #
+  # @param identifiers [Enumerable] list of identifiers
+  # @param source [String] entity URL fragment or backend fragment name, defaults to `params.fetch(:entity)`
+  # @param target [Occi::Core::Locations] instance to be populated, defaults to a new instance
+  # @return [Occi::Core::Locations] converted structure
+  def locations_from(identifiers, source = nil, target = nil)
+    source ||= params[:entity]
+    raise 'Cannot create locations without valid source' if source.blank?
+    target ||= Occi::Core::Locations.new
+
+    identifiers.each do |id|
+      relative_url = "#{linkish?(source) ? LINK_PATH_PREFIX : '/'}#{source}/#{id}"
+      target << absolute_url(relative_url)
+    end
+    target.valid!
+
+    target
+  end
+
+  # Checks whether the given entity belongs to Link-like entity subtypes.
+  #
+  # @param entity [String] entity name, from URL (i.e., term-like)
+  # @return [TrueClass] if certain linkiness is suggested
+  # @return [FalseClass] if NOT
+  def linkish?(entity)
+    BackendProxy.linklike?(entity.to_sym)
+  end
+
+  # @see `linkish?`
+  def resourceish?(entity)
+    BackendProxy.resourcelike?(entity.to_sym)
+  end
+end

--- a/app/controllers/entity_controller.rb
+++ b/app/controllers/entity_controller.rb
@@ -1,10 +1,9 @@
 class EntityController < ApplicationController
   include ParserAccessible
-
-  # A way to separate Resources from Links
-  LINK_PATH_PREFIX = '/link/'.freeze
+  include LocationsTransformable
 
   before_action :entitylike!
+  before_action :matching_path!
   before_action :validate_provided_format!, only: %i[create execute execute_all update partial_update]
   before_action :instance_exists!, only: %i[show execute update partial_update delete]
 
@@ -95,8 +94,14 @@ class EntityController < ApplicationController
   # a valid Entity-like term. If not, this will render and return
   # HTTP[404].
   def entitylike!
-    return if backend_proxy.entitylike?(params[:entity].to_sym)
+    return if BackendProxy.entitylike?(params[:entity].to_sym)
     render_error :not_found, 'Requested entity type could not be found'
+  end
+
+  # Checks whether Entity-like instance is accessed via the corresponding
+  # path (relative URL). If not, this will render and return HTTP[404].
+  def matching_path!
+    link_path? || resource_path? || render_error(:not_found, 'Mismatched entity type and collection path')
   end
 
   # Checks whether `:id` specified in `params` is actually an
@@ -107,36 +112,11 @@ class EntityController < ApplicationController
     render_error :not_found, 'Requested instance could not be found'
   end
 
-  # Converts given enumerable structure to an instance of `Occi::Core::Locations`
-  # for later rendering or further processing.
-  #
-  # @param identifiers [Enumerable] list of identifiers
-  # @return [Occi::Core::Locations] converted structure
-  def locations_from(identifiers)
-    locations = Occi::Core::Locations.new
-
-    identifiers.each do |id|
-      relative_url = "#{linkish? ? LINK_PATH_PREFIX : '/'}#{params[:entity]}/#{id}"
-      locations << absolute_url(relative_url)
-    end
-    locations.valid!
-
-    locations
-  end
-
-  # Checks whether the current request should assume Link-like entity subtypes.
-  #
-  # @return [TrueClass] if request path suggests certain linkiness
-  # @return [FalseClass] if NOT
-  def linkish?
-    request.original_fullpath.start_with?(LINK_PATH_PREFIX)
-  end
-
   # Attempts to parse and return the correct instance collection for this request type.
   #
   # @return [Set] collection of instances
   def resources_or_links
-    linkish? ? request_links : request_resources
+    linkish?(params[:entity]) ? request_links : request_resources
   end
 
   # Returns default backend instance for the given controller.
@@ -144,5 +124,15 @@ class EntityController < ApplicationController
   # @return [Entitylike, Extenderlike] subtype instance
   def default_backend_proxy
     backend_proxy_for params[:entity]
+  end
+
+  # :nodoc:
+  def resource_path?
+    resourceish?(params[:entity]) && !request.original_fullpath.start_with?(link_path_prefix)
+  end
+
+  # :nodoc:
+  def link_path?
+    linkish?(params[:entity]) && request.original_fullpath.start_with?(link_path_prefix)
   end
 end

--- a/app/models/backend_proxy.rb
+++ b/app/models/backend_proxy.rb
@@ -2,30 +2,64 @@ module Backends; end
 Dir.glob(File.join(File.dirname(__FILE__), 'backends', '*.rb')) { |mod| require mod.chomp('.rb') }
 
 class BackendProxy
-  #
+  # Available backends (supported platforms)
   BACKEND_TYPES = {
     dummy: Backends::Dummy,
     opennebula: Backends::OpenNebula,
     aws_ec2: Backends::AwsEc2
   }.freeze
 
-  #
-  BACKEND_ENTITY_SUBTYPES = %i[
+  # Available backend fragments (supported types of resources)
+  BACKEND_RESOURCE_SUBTYPES = %i[
     compute network storage securitygroup ipreservation
+  ].freeze
+
+  # Available backend fragments (supported types of links)
+  BACKEND_LINK_SUBTYPES = %i[
     storagelink networkinterface securitygrouplink
   ].freeze
+
+  # Available backend fragments (supported types of entities)
+  BACKEND_ENTITY_SUBTYPES = [
+    BACKEND_RESOURCE_SUBTYPES,
+    BACKEND_LINK_SUBTYPES
+  ].flatten.freeze
+
+  # Available backend fragments (supported types of non-entities)
   BACKEND_NON_ENTITY_SUBTYPES = %i[model_extender].freeze
+
+  # Available backend fragments (all)
   BACKEND_SUBTYPES = [
     BACKEND_ENTITY_SUBTYPES,
     BACKEND_NON_ENTITY_SUBTYPES
   ].flatten.freeze
 
-  #
+  # Required version of the backend API
   API_VERSION = '3.0.0'.freeze
 
   attr_accessor :type, :options, :logger
-  delegate :api_version, to: :class
 
+  # Make various static methods available on instances
+  DELEG_METHODS = %i[
+    api_version can_be? has? entitylike? resourcelike? linklike?
+    backend_types backend_subtypes
+    backend_resource_subtypes backend_link_subtypes
+    backend_entity_subtypes backend_non_entity_subtypes
+  ].freeze
+  delegate(*DELEG_METHODS, to: :class)
+
+  # Constructs an instance of the backend proxy. This instance can be
+  # used to access various backend fragments on demand.
+  #
+  # @example
+  #    bp = BackendProxy.new(type: :opennebula, options: {}, logger: Rails.logger)
+  #    bp.compute.create(instance)
+  #    bp.storage.identifiers
+  #
+  # @param args [Hash] constructor arguments
+  # @option args [Symbol] :type type of the backend, see `backend_types`
+  # @option args [Hash] :options backend-specific options
+  # @option args [Logger] :logger logger instance
   def initialize(args = {})
     @type = args.fetch(:type)
     @options = args.fetch(:options)
@@ -34,18 +68,16 @@ class BackendProxy
     flush!
   end
 
+  # Flushes (or initializes) internal backend fragment cache.
   def flush!
     @_cache = {}
   end
 
+  # Checks type of backend used for this instance.
   #
-  # @param btype [Symbol] backend type
-  # @return [TrueClass] if such backend type is available
-  # @return [FalseClass] if such backend type is NOT available
-  def can_be?(btype)
-    known_backend_types.keys.include?(btype)
-  end
-
+  # @example
+  #    bp.is? :opennebula  # => true
+  #    bp.is? :dummy       # => false
   #
   # @param btype [Symbol] backend type
   # @return [TrueClass] if backend type matches loaded type
@@ -54,59 +86,102 @@ class BackendProxy
     type == btype
   end
 
-  #
-  # @param bsubtype [Symbol] backend subtype
-  # @return [TrueClass] if backend subtype is available
-  # @return [FalseClass] if backend subtype is NOT available
-  def has?(bsubtype)
-    known_backend_subtypes.include?(bsubtype)
-  end
-
-  #
-  # @param bsubtype [Symbol] backend subtype
-  # @return [TrueClass] if backend subtype is serving something Entity-like
-  # @return [FalseClass] if backend subtype is NOT serving anything Entity-like
-  def entitylike?(bsubtype)
-    known_backend_entity_subtypes.include?(bsubtype)
-  end
-
-  #
-  # @return [Hash] map of available backend types, `type` => `namespace`
-  def known_backend_types
-    BACKEND_TYPES
-  end
-
-  #
-  # @return [Array] list of available backend subtypes
-  def known_backend_subtypes
-    BACKEND_SUBTYPES
-  end
-
-  #
-  # @return [Array] list of available backend subtypes serving something Entity-like
-  def known_backend_entity_subtypes
-    BACKEND_ENTITY_SUBTYPES
-  end
-
-  #
-  # @return [Array] list of available backend subtypes serving nothing Entity-like
-  def known_backend_non_entity_subtypes
-    BACKEND_NON_ENTITY_SUBTYPES
-  end
-
   class << self
+    # Returns backend API version required by this proxy class.
     #
     # @return [String] version of the backend API, semantic
     def api_version
       API_VERSION
     end
+
+    # Checks whether this proxy class provides access to the given backend
+    # type.
+    #
+    # @example
+    #    BackendProxy.can_be? :weird  #=> false
+    #    BackendProxy.can_be? :dummy  #=> true
+    #
+    # @param btype [Symbol] backend type
+    # @return [TrueClass] if such backend type is available
+    # @return [FalseClass] if such backend type is NOT available
+    def can_be?(btype)
+      backend_types.keys.include?(btype)
+    end
+
+    # Checks whether this proxy class provides access to the given backend subtype/fragment.
+    #
+    # @example
+    #    BackendProxy.has? :compute #=> true
+    #    BackendProxy.has? :meh     #=> false
+    #
+    # @param bsubtype [Symbol] backend subtype
+    # @return [TrueClass] if backend subtype is available
+    # @return [FalseClass] if backend subtype is NOT available
+    def has?(bsubtype)
+      backend_subtypes.include?(bsubtype)
+    end
+
+    # Checks whether this proxy class provides access to an Entity-like backend
+    # subtype/fragment.
+    #
+    # @example
+    #    BackendProxy.entitylike? :compute        #=> true
+    #    BackendProxy.entitylike? :model_extender #=> false
+    #
+    # @param bsubtype [Symbol] backend subtype
+    # @return [TrueClass] if backend subtype is serving something Entity-like
+    # @return [FalseClass] if backend subtype is NOT serving anything Entity-like
+    def entitylike?(bsubtype)
+      backend_entity_subtypes.include?(bsubtype)
+    end
+
+    # @see `entitylike?`
+    def resourcelike?(bsubtype)
+      backend_resource_subtypes.include?(bsubtype)
+    end
+
+    # @see `entitylike?`
+    def linklike?(bsubtype)
+      backend_link_subtypes.include?(bsubtype)
+    end
+
+    # @return [Hash] map of available backend types, `type` => `namespace`
+    def backend_types
+      BACKEND_TYPES
+    end
+
+    # @return [Array] list of available backend subtypes
+    def backend_subtypes
+      BACKEND_SUBTYPES
+    end
+
+    # @return [Array] list of available backend subtypes serving something Resource-like
+    def backend_resource_subtypes
+      BACKEND_RESOURCE_SUBTYPES
+    end
+
+    # @return [Array] list of available backend subtypes serving something Link-like
+    def backend_link_subtypes
+      BACKEND_LINK_SUBTYPES
+    end
+
+    # @return [Array] list of available backend subtypes serving something Entity-like
+    def backend_entity_subtypes
+      BACKEND_ENTITY_SUBTYPES
+    end
+
+    # @return [Array] list of available backend subtypes serving nothing Entity-like
+    def backend_non_entity_subtypes
+      BACKEND_NON_ENTITY_SUBTYPES
+    end
   end
 
   private
 
+  # :nodoc:
   def method_missing(m, *args, &block)
     m = m.to_sym
-    if known_backend_subtypes.include?(m)
+    if backend_subtypes.include?(m)
       logger.debug "Creating a proxy for #{m} (#{type} backend)"
       @_cache[m] ||= initialize_proxy(m)
     else
@@ -114,30 +189,35 @@ class BackendProxy
     end
   end
 
+  # :nodoc:
   def respond_to_missing?(method_name, include_private = false)
     has?(method_name.to_sym) || super
   end
 
+  # :nodoc:
   def initialize_proxy(subtype)
     bklass = klass_in_namespace(backend_namespace, subtype)
     check_version! api_version, bklass.api_version
     bklass.new default_backend_options.merge(options)
   end
 
+  # :nodoc:
   def default_backend_options
     { logger: logger, backend_proxy: self }
   end
 
+  # :nodoc:
   def backend_namespace
-    unless known_backend_types.key?(type)
+    unless backend_types.key?(type)
       raise Errors::BackendLoadError, "Backend type #{type} is not supported"
     end
 
-    known_backend_types[type]
+    backend_types[type]
   end
 
+  # :nodoc:
   def klass_in_namespace(backend_module, subtype)
-    unless known_backend_subtypes.include?(subtype)
+    unless backend_subtypes.include?(subtype)
       raise Errors::BackendLoadError, "Backend subtype #{subtype} is not supported"
     end
 
@@ -149,6 +229,7 @@ class BackendProxy
     backend_module.const_get(bsklass)
   end
 
+  # :nodoc:
   def check_version!(server_version, backend_version)
     s_major, s_minor = server_version.split('.')
     b_major, b_minor = backend_version.split('.')


### PR DESCRIPTION
## Overview
When accessing root locations of the server (i.e., `GET /` or `DELETE /`), tasks must be performed on all available Entity-like instances. This is done in `MultiEntityController`, currently only partially implemented (as planned). In order to generate valid locations and correctly add the `/link/` prefix to path, this controller needs to be able to distinguish between Link-like and Resource-like instances.

## Changes
* Updated `BackendProxy` to distinguish between Resource-like and Link-like backend subtypes
* Created `LocationsTransformable` controller concern handling path prefixing
* Updated `*EntityController` to integrate `LocationsTransformable`
* Implemented `locations` and `delete_all` on `MultiEntityController`