### PR TITLE
Dummy backend implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'rack-cors', '~> 0.4'
 gem 'rails', '~> 5.1.1'
 gem 'responders', '~> 2.4.0'
 
-gem 'occi-core', '= 5.0.0.beta.5', require: 'occi/infrastructure-ext' # '~> 5.0.0'
+gem 'occi-core', '= 5.0.0.beta.6', require: 'occi/infrastructure-ext' # '~> 5.0.0'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
-    occi-core (5.0.0.beta.5)
+    occi-core (5.0.0.beta.6)
       activesupport (>= 4.0, < 6)
       json (>= 1.8, < 3)
       json-schema (>= 2.5, < 3)
@@ -198,7 +198,7 @@ DEPENDENCIES
   byebug
   listen (>= 3.0.5, < 3.2)
   logstasher (~> 1.2)
-  occi-core (= 5.0.0.beta.5)
+  occi-core (= 5.0.0.beta.6)
   opennebula (~> 5.2)
   puma (~> 3.7)
   rack-attack (~> 5.0.1)

--- a/app/controllers/concerns/backend_accessible.rb
+++ b/app/controllers/concerns/backend_accessible.rb
@@ -3,8 +3,9 @@ module BackendAccessible
 
   # Returns and caches instance of the `BackendProxy` class.
   #
+  # @param with_model [TrueClass, FalseClass] whether to include `server_model` reference
   # @return [BackendProxy] instance of the `BackendProxy` class
-  def backend_proxy
+  def backend_proxy(with_model = true)
     return @_backend_proxy if @_backend_proxy
 
     backend_type = app_config.fetch('backend')
@@ -14,6 +15,9 @@ module BackendAccessible
       options: app_config.fetch(backend_type, {}),
       logger: logger
     )
+    @_backend_proxy.server_model = server_model if with_model
+
+    @_backend_proxy
   end
 
   # Returns backend instance of the given subtype.
@@ -25,6 +29,7 @@ module BackendAccessible
   # @return [Entitylike, Extenderlike] subtype instance
   def backend_proxy_for(subtype)
     raise "#{subtype.inspect} is not a supported backend subtype" unless backend_proxy.has?(subtype.to_sym)
-    backend_proxy.send subtype
+    with_model = (subtype != 'model_extender')
+    backend_proxy(with_model).send subtype
   end
 end

--- a/app/models/backend_proxy.rb
+++ b/app/models/backend_proxy.rb
@@ -37,7 +37,7 @@ class BackendProxy
   # Required version of the backend API
   API_VERSION = '3.0.0'.freeze
 
-  attr_accessor :type, :options, :logger
+  attr_accessor :type, :options, :logger, :server_model
 
   # Make various static methods available on instances
   DELEG_METHODS = %i[
@@ -60,10 +60,12 @@ class BackendProxy
   # @option args [Symbol] :type type of the backend, see `backend_types`
   # @option args [Hash] :options backend-specific options
   # @option args [Logger] :logger logger instance
+  # @option args [Occi::Core::Model] :server_model instance of the server model (OCCI)
   def initialize(args = {})
     @type = args.fetch(:type)
     @options = args.fetch(:options)
     @logger = args.fetch(:logger)
+    @server_model = args.fetch(:server_model, nil)
 
     flush!
   end

--- a/app/models/backends/dummy/compute.rb
+++ b/app/models/backends/dummy/compute.rb
@@ -1,14 +1,17 @@
-require 'backends/dummy/base'
+require 'backends/dummy/entity_base'
 
 module Backends
   module Dummy
-    class Compute < Base
-      include Entitylike
-
+    class Compute < EntityBase
       class << self
         # @see `served_class` on `Entitylike`
         def served_class
           Occi::Infrastructure::Compute
+        end
+
+        # :nodoc:
+        def entity_identifier
+          Occi::Infrastructure::Constants::COMPUTE_KIND
         end
       end
     end

--- a/app/models/backends/dummy/entity_base.rb
+++ b/app/models/backends/dummy/entity_base.rb
@@ -1,0 +1,72 @@
+require 'backends/dummy/base'
+
+module Backends
+  module Dummy
+    class EntityBase < Base
+      include Entitylike
+
+      # Dummies
+      DUMMY_IDS = %w[
+        a262ad95-c093-4814-8c0d-bc6d475bb845
+        5124f8c0-cecb-41ca-b0c9-106f10c2db1e
+        8b3e4362-b761-4eed-a6f3-69e271f90286
+      ].freeze
+
+      # @see `Entitylike`
+      def identifiers(_filter = Set.new)
+        Set.new(DUMMY_IDS)
+      end
+
+      # @see `Entitylike`
+      def list(_filter = Set.new)
+        coll = Occi::Core::Collection.new
+        DUMMY_IDS.each { |id| coll << instance(id) }
+        coll
+      end
+
+      # @see `Entitylike`
+      def instance(identifier)
+        instance = instance_builder.get(self.class.entity_identifier)
+        instance['occi.core.id'] = identifier
+        instance['occi.core.title'] = identifier
+        instance
+      end
+
+      # @see `Entitylike`
+      def create(instance)
+        instance['occi.core.id'] = DUMMY_IDS.first
+        instance['occi.core.id']
+      end
+
+      # @see `Entitylike`
+      def partial_update(identifier, _fragments)
+        instance identifier
+      end
+
+      # @see `Entitylike`
+      def update(identifier, _new_instance)
+        instance identifier
+      end
+
+      # @see `Entitylike`
+      def trigger(identifier, _action_instance)
+        identifier
+      end
+
+      # @see `Entitylike`
+      def trigger_all(_action_instance, _filter = Set.new)
+        Set.new
+      end
+
+      # @see `Entitylike`
+      def delete(identifier)
+        identifier
+      end
+
+      # @see `Entitylike`
+      def delete_all(_filter = Set.new)
+        Set.new
+      end
+    end
+  end
+end

--- a/app/models/backends/dummy/ipreservation.rb
+++ b/app/models/backends/dummy/ipreservation.rb
@@ -1,14 +1,17 @@
-require 'backends/dummy/base'
+require 'backends/dummy/entity_base'
 
 module Backends
   module Dummy
-    class Ipreservation < Base
-      include Entitylike
-
+    class Ipreservation < EntityBase
       class << self
         # @see `served_class` on `Entitylike`
         def served_class
           Occi::InfrastructureExt::IPReservation
+        end
+
+        # :nodoc:
+        def entity_identifier
+          Occi::InfrastructureExt::Constants::IPRESERVATION_KIND
         end
       end
     end

--- a/app/models/backends/dummy/network.rb
+++ b/app/models/backends/dummy/network.rb
@@ -1,14 +1,17 @@
-require 'backends/dummy/base'
+require 'backends/dummy/entity_base'
 
 module Backends
   module Dummy
-    class Network < Base
-      include Entitylike
-
+    class Network < EntityBase
       class << self
         # @see `served_class` on `Entitylike`
         def served_class
           Occi::Infrastructure::Network
+        end
+
+        # :nodoc:
+        def entity_identifier
+          Occi::Infrastructure::Constants::NETWORK_KIND
         end
       end
     end

--- a/app/models/backends/dummy/networkinterface.rb
+++ b/app/models/backends/dummy/networkinterface.rb
@@ -1,14 +1,17 @@
-require 'backends/dummy/base'
+require 'backends/dummy/entity_base'
 
 module Backends
   module Dummy
-    class Networkinterface < Base
-      include Entitylike
-
+    class Networkinterface < EntityBase
       class << self
         # @see `served_class` on `Entitylike`
         def served_class
           Occi::Infrastructure::Networkinterface
+        end
+
+        # :nodoc:
+        def entity_identifier
+          Occi::Infrastructure::Constants::NETWORKINTERFACE_KIND
         end
       end
     end

--- a/app/models/backends/dummy/securitygroup.rb
+++ b/app/models/backends/dummy/securitygroup.rb
@@ -1,14 +1,17 @@
-require 'backends/dummy/base'
+require 'backends/dummy/entity_base'
 
 module Backends
   module Dummy
-    class Securitygroup < Base
-      include Entitylike
-
+    class Securitygroup < EntityBase
       class << self
         # @see `served_class` on `Entitylike`
         def served_class
           Occi::InfrastructureExt::SecurityGroup
+        end
+
+        # :nodoc:
+        def entity_identifier
+          Occi::InfrastructureExt::Constants::SECURITY_GROUP_KIND
         end
       end
     end

--- a/app/models/backends/dummy/securitygrouplink.rb
+++ b/app/models/backends/dummy/securitygrouplink.rb
@@ -1,14 +1,17 @@
-require 'backends/dummy/base'
+require 'backends/dummy/entity_base'
 
 module Backends
   module Dummy
-    class Securitygrouplink < Base
-      include Entitylike
-
+    class Securitygrouplink < EntityBase
       class << self
         # @see `served_class` on `Entitylike`
         def served_class
           Occi::InfrastructureExt::SecurityGroupLink
+        end
+
+        # :nodoc:
+        def entity_identifier
+          Occi::InfrastructureExt::Constants::SECURITY_GROUP_LINK_KIND
         end
       end
     end

--- a/app/models/backends/dummy/storage.rb
+++ b/app/models/backends/dummy/storage.rb
@@ -1,14 +1,17 @@
-require 'backends/dummy/base'
+require 'backends/dummy/entity_base'
 
 module Backends
   module Dummy
-    class Storage < Base
-      include Entitylike
-
+    class Storage < EntityBase
       class << self
         # @see `served_class` on `Entitylike`
         def served_class
           Occi::Infrastructure::Storage
+        end
+
+        # :nodoc:
+        def entity_identifier
+          Occi::Infrastructure::Constants::STORAGE_KIND
         end
       end
     end

--- a/app/models/backends/dummy/storagelink.rb
+++ b/app/models/backends/dummy/storagelink.rb
@@ -1,14 +1,17 @@
-require 'backends/dummy/base'
+require 'backends/dummy/entity_base'
 
 module Backends
   module Dummy
-    class Storagelink < Base
-      include Entitylike
-
+    class Storagelink < EntityBase
       class << self
         # @see `served_class` on `Entitylike`
         def served_class
           Occi::Infrastructure::Storagelink
+        end
+
+        # :nodoc:
+        def entity_identifier
+          Occi::Infrastructure::Constants::STORAGELINK_KIND
         end
       end
     end

--- a/app/models/concerns/entitylike.rb
+++ b/app/models/concerns/entitylike.rb
@@ -3,6 +3,8 @@ module Entitylike
 
   included do
     delegate :serves?, to: :class
+    delegate :server_model, to: :backend_proxy
+    delegate :instance_builder, to: :server_model
   end
 
   class_methods do


### PR DESCRIPTION
## Overview
`Dummy` backend offers a simple testing mechanism. Its content is static, immutable, and changes ephemeral.

## Changes
* Passing `server_model` to backend instances (needed for `instance_builder`)
* Impl `Backends::Dummy` with trivial responses