### PR TITLE
Basic actions for compute and storage in ONe

### DIFF
--- a/app/controllers/concerns/errorable.rb
+++ b/app/controllers/concerns/errorable.rb
@@ -76,7 +76,7 @@ module Errorable
   # @param exception [Exception] exception to convert into a response
   def action_error(exception)
     log_message! exception
-    render_error :conflict, "Failed to perform requested change: #{message}"
+    render_error :conflict, "Failed to perform requested change: #{exception}"
   end
 
   # @param exception [Exception] exception to convert into a response

--- a/app/controllers/entity_controller.rb
+++ b/app/controllers/entity_controller.rb
@@ -59,7 +59,8 @@ class EntityController < ApplicationController
       return
     end
 
-    default_backend_proxy.trigger params[:id], coll.first
+    ret_coll = default_backend_proxy.trigger(params[:id], coll.first)
+    respond_with ret_coll unless ret_coll.empty?
   end
 
   # POST /:entity/?action=ACTION
@@ -70,7 +71,8 @@ class EntityController < ApplicationController
       return
     end
 
-    default_backend_proxy.trigger_all coll.first
+    ret_coll = default_backend_proxy.trigger_all(coll.first)
+    respond_with ret_coll unless ret_coll.empty?
   end
 
   # PUT /:entity/:id

--- a/app/lib/backends/dummy/entity_base.rb
+++ b/app/lib/backends/dummy/entity_base.rb
@@ -44,8 +44,8 @@ module Backends
       end
 
       # @see `Entitylike`
-      def trigger(identifier, _action_instance)
-        identifier
+      def trigger(_identifier, _action_instance)
+        Occi::Core::Collection.new
       end
 
       # @see `Entitylike`

--- a/app/lib/backends/helpers/entitylike.rb
+++ b/app/lib/backends/helpers/entitylike.rb
@@ -107,7 +107,7 @@ module Backends
       #
       # @param identifier [String] UUID of the requested entity
       # @param action_instance [Occi::Core::ActionInstance] action to be triggered
-      # @return [String] identifier of the affected entity
+      # @return [Occi::Core::Collection] result(s) of the action, in a collection
       def trigger(_identifier, _action_instance)
         raise Errors::Backend::NotImplementedError, 'Requested functionality is not implemented'
       end
@@ -117,9 +117,11 @@ module Backends
       #
       # @param action_instance [Occi::Core::ActionInstance] action to be triggered
       # @param filter [Set] collection of filtering rules
-      # @return [Set] collection of identifiers of affected entities
-      def trigger_all(_action_instance, _filter = Set.new)
-        Set.new(identifiers(filter).map { |id| trigger(id, action_instance) })
+      # @return [Occi::Core::Collection] result(s) of the action, in a collection
+      def trigger_all(action_instance, filter = Set.new)
+        collection = Occi::Core::Collection.new
+        identifiers(filter).each { |id| collection.categories.merge trigger(id, action_instance).categories }
+        collection
       end
 
       # Destroys an instance specified by `identifier`. An appropriate error should be raised in case of failure.

--- a/app/lib/backends/opennebula/compute.rb
+++ b/app/lib/backends/opennebula/compute.rb
@@ -47,6 +47,18 @@ module Backends
       end
 
       # @see `Entitylike`
+      def trigger(identifier, action_instance)
+        name = action_instance.action.term
+        vm = pool_element(:virtual_machine, identifier)
+        client(Errors::Backend::EntityActionError) do
+          Constants::Compute::ACTIONS[name].call(vm, action_instance)
+        end
+
+        # TODO: return os_tpl mixin for `save`
+        Occi::Core::Collection.new
+      end
+
+      # @see `Entitylike`
       def delete(identifier)
         vm = pool_element(:virtual_machine, identifier)
         client(Errors::Backend::EntityActionError) { vm.terminate(true) }
@@ -103,9 +115,9 @@ module Backends
       def enable_actions!(compute)
         actions = case compute['occi.compute.state']
                   when 'active'
-                    Constants::Compute::ACTIVE_ACTIONS
+                    Constants::Compute::ACTIVE_ACTIONS.keys
                   when 'inactive'
-                    Constants::Compute::INACTIVE_ACTIONS
+                    Constants::Compute::INACTIVE_ACTIONS.keys
                   else
                     []
                   end

--- a/app/lib/backends/opennebula/constants/compute.rb
+++ b/app/lib/backends/opennebula/constants/compute.rb
@@ -59,8 +59,23 @@ module Backends
         }.freeze
 
         # Actions to enable when active
-        ACTIVE_ACTIONS = %w[stop restart suspend save].freeze
-        INACTIVE_ACTIONS = %w[start].freeze
+        ACTIVE_ACTIONS = {
+          'stop' => ->(vm, _ai) { vm.poweroff(true) },
+          'restart' => ->(vm, _ai) { vm.reboot(true) },
+          'suspend' => ->(vm, _ai) { vm.suspend }
+        }.freeze
+
+        # Actions to enable when inactive
+        INACTIVE_ACTIONS = {
+          'start' => ->(vm, _ai) { vm.resume },
+          'save' => lambda do |vm, ai|
+            template_name = ai['name'].present? ? ai['name'] : "saved-compute-#{vm['ID']}-#{Time.now.utc.to_i}"
+            vm.save_as_template(template_name, true)
+          end
+        }.freeze
+
+        # All actions
+        ACTIONS = ACTIVE_ACTIONS.merge(INACTIVE_ACTIONS).freeze
       end
     end
   end

--- a/app/lib/backends/opennebula/constants/storage.rb
+++ b/app/lib/backends/opennebula/constants/storage.rb
@@ -27,7 +27,9 @@ module Backends
         TRANSFERABLE_ATTRIBUTES = [ATTRIBUTES_CORE, ATTRIBUTES_INFRA].freeze
 
         # Actions to enable when online
-        ONLINE_ACTIONS = %w[backup].freeze
+        ONLINE_ACTIONS = {
+          'backup' => ->(image, _ai) { image.clone "storage-#{image['ID']}-#{Time.now.utc.to_i}" }
+        }.freeze
       end
     end
   end

--- a/app/lib/backends/opennebula/storage.rb
+++ b/app/lib/backends/opennebula/storage.rb
@@ -43,6 +43,17 @@ module Backends
       end
 
       # @see `Entitylike`
+      def trigger(identifier, action_instance)
+        name = action_instance.action.term
+        image = pool_element(:image, identifier)
+        client(Errors::Backend::EntityActionError) do
+          Constants::Storage::ONLINE_ACTIONS[name].call(image, action_instance)
+        end
+
+        Occi::Core::Collection.new
+      end
+
+      # @see `Entitylike`
       def delete(identifier)
         image = pool_element(:image, identifier)
         client(Errors::Backend::EntityStateError) { image.delete }
@@ -87,7 +98,7 @@ module Backends
       # :nodoc:
       def enable_actions!(storage)
         return unless storage['occi.storage.state'] == 'online'
-        Constants::Storage::ONLINE_ACTIONS.each { |a| storage.enable_action(a) }
+        Constants::Storage::ONLINE_ACTIONS.keys.each { |a| storage.enable_action(a) }
       end
 
       # :nodoc:


### PR DESCRIPTION
## Changes
* `trigger` and `trigger_all` now return `Occi::Core::Collection` instead of `String`/`Set` with identifier(s)
* Implemented trivial actions for `compute`
* Implemented trivial actions for `storage`